### PR TITLE
Homepage side submenu background repeat fix when scrolling the page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.sublime*
 .sass-cache
 *.DS_Store
+.idea

--- a/source/css/partials/home/_submenu.scss
+++ b/source/css/partials/home/_submenu.scss
@@ -26,7 +26,7 @@ aside {
     padding: 0;
 
     li {
-      padding: 9px 0;
+      padding: 8px 0;
       display: block;
 
       a {
@@ -35,8 +35,9 @@ aside {
         color: #333;
         font: 14px gotham_light;
         display: block;
-        padding-left: 5px;
         border-left: 2px solid transparent;
+        background-repeat: no-repeat;
+        padding: 1px 0 1px 5px;
 
         @include apply-to(more-than, desktop) {
           font-size: 15px;


### PR DESCRIPTION
There was small bug while scrolling homepage, transition effect is causing that no-repeat rule is not applied on li>a elements from the side menu so you can see repeated tiny-icon.png image for a moment while the transition effect is occurred.
